### PR TITLE
Add desktop stubs for audio_waveforms plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-## Flutter ###
-# Flutter/Dart/Pub related
+# Flutter related
 **/doc/api/
 .dart_tool/
 .flutter-plugins
@@ -46,8 +45,7 @@ build/
 **/ios/Runner/GeneratedPluginRegistrant.*
 **/ios/Runner.xcworkspace/xcshareddata/
 
-
-# Exceptions to above rules.
+# Exceptions
 !**/ios/**/default.mode1v3
 !**/ios/**/default.mode2v3
 !**/ios/**/default.pbxuser
@@ -55,7 +53,6 @@ build/
 !/packages/flutter_tools/test/data/dart_dependencies_test/**/.packages
 
 /audio_waveforms.iml
-
 .idea/instapk.xml
 instapk.log*
 ios/Frameworks/
@@ -63,3 +60,4 @@ ios/Runner.xcworkspace/xcshareddata/
 example/ios/Flutter/flutter_export_environment.sh
 audio_waveforms.iml
 pubspec.lock
+flutter-sdk/

--- a/README.md
+++ b/README.md
@@ -38,6 +38,25 @@ Add RECORD_AUDIO permission in `AndroidManifest.xml`
 ```
 </details>
 <details>
+<summary>Desktop</summary>
+
+To experiment with desktop platforms you must configure microphone access on each
+operating system.
+
+**macOS**
+
+- Add a microphone usage description to `macos/Runner/Info.plist`.
+
+**Windows**
+
+- Declare the `microphone` capability in the application manifest.
+
+**Linux**
+
+- Ensure PulseAudio (or another supported backend) is available.
+
+</details>
+<details>
 <summary>IOS</summary>
 
 Add description to your microphone usage in `ios/Runner/Info.plist`,

--- a/lib/src/base/audio_waveforms_interface.dart
+++ b/lib/src/base/audio_waveforms_interface.dart
@@ -17,7 +17,7 @@ class AudioWaveformsInterface {
   }) async {
     final isRecording = await _methodChannel.invokeMethod(
       Constants.startRecording,
-      Platform.isIOS
+      (Platform.isIOS || Platform.isMacOS)
           ? recorderSetting.iosToJson(
               path: path,
               overrideAudioSession: overrideAudioSession,

--- a/lib/src/controllers/recorder_controller.dart
+++ b/lib/src/controllers/recorder_controller.dart
@@ -25,7 +25,7 @@ class RecorderController extends ChangeNotifier {
   double normalizationFactor = Platform.isAndroid ? 60 : 40;
 
   /// Current maximum peak power for ios and peak amplitude android.
-  double _maxPeak = Platform.isIOS ? 1 : 32786.0;
+  double _maxPeak = (Platform.isIOS || Platform.isMacOS) ? 1 : 32786.0;
 
   /// Current min value.
   double _currentMin = 0;
@@ -197,7 +197,7 @@ class RecorderController extends ChangeNotifier {
           notifyListeners();
           return;
         }
-        if (Platform.isIOS) {
+        if (Platform.isIOS || Platform.isMacOS) {
           _setRecorderState(RecorderState.initialized);
         }
         if (_recorderState.isInitialized) {

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -1,0 +1,20 @@
+cmake_minimum_required(VERSION 3.10)
+set(PROJECT_NAME "audio_waveforms")
+project(${PROJECT_NAME} LANGUAGES CXX)
+set(PLUGIN_NAME "audio_waveforms_plugin")
+list(APPEND PLUGIN_SOURCES
+  "audio_waveforms_plugin.cc"
+)
+add_library(${PLUGIN_NAME} SHARED
+  ${PLUGIN_SOURCES}
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter)
+target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::GTK)
+set(audio_waveforms_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/linux/audio_waveforms_plugin.cc
+++ b/linux/audio_waveforms_plugin.cc
@@ -1,0 +1,53 @@
+#include "include/audio_waveforms/audio_waveforms_plugin.h"
+
+#include <flutter_linux/flutter_linux.h>
+#include <gtk/gtk.h>
+
+struct _AudioWaveformsPlugin {
+  GObject parent_instance;
+};
+
+G_DEFINE_TYPE(AudioWaveformsPlugin, audio_waveforms_plugin, g_object_get_type())
+
+// Called when a method call is received from Flutter.
+static void audio_waveforms_plugin_handle_method_call(
+    AudioWaveformsPlugin* self,
+    FlMethodCall* method_call) {
+  g_autoptr(FlMethodResponse) response = nullptr;
+  response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+      "UNIMPLEMENTED",
+      "AudioWaveforms desktop support is not yet implemented",
+      fl_value_new_string(fl_method_call_get_name(method_call))));
+  fl_method_call_respond(method_call, response, nullptr);
+}
+
+static void audio_waveforms_plugin_dispose(GObject* object) {
+  G_OBJECT_CLASS(audio_waveforms_plugin_parent_class)->dispose(object);
+}
+
+static void audio_waveforms_plugin_class_init(AudioWaveformsPluginClass* klass) {
+  G_OBJECT_CLASS(klass)->dispose = audio_waveforms_plugin_dispose;
+}
+
+static void audio_waveforms_plugin_init(AudioWaveformsPlugin* self) {}
+
+static void method_call_cb(FlMethodChannel* channel, FlMethodCall* method_call,
+                           gpointer user_data) {
+  AudioWaveformsPlugin* plugin = AUDIO_WAVEFORMS_PLUGIN(user_data);
+  audio_waveforms_plugin_handle_method_call(plugin, method_call);
+}
+
+void audio_waveforms_plugin_register_with_registrar(FlPluginRegistrar* registrar) {
+  AudioWaveformsPlugin* plugin = AUDIO_WAVEFORMS_PLUGIN(
+      g_object_new(audio_waveforms_plugin_get_type(), nullptr));
+
+  g_autoptr(FlStandardMethodCodec) codec = fl_standard_method_codec_new();
+  g_autoptr(FlMethodChannel) channel = fl_method_channel_new(
+      fl_plugin_registrar_get_messenger(registrar),
+      "simform_audio_waveforms_plugin/methods",
+      FL_METHOD_CODEC(codec));
+  fl_method_channel_set_method_call_handler(channel, method_call_cb,
+                                            g_object_ref(plugin),
+                                            g_object_unref);
+  g_object_unref(plugin);
+}

--- a/linux/include/audio_waveforms/audio_waveforms_plugin.h
+++ b/linux/include/audio_waveforms/audio_waveforms_plugin.h
@@ -1,0 +1,14 @@
+#ifndef FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_
+#define FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_
+
+#include <flutter_linux/flutter_linux.h>
+
+G_BEGIN_DECLS
+
+G_DECLARE_FINAL_TYPE(AudioWaveformsPlugin, audio_waveforms_plugin, AUDIO_WAVEFORMS, PLUGIN, GObject)
+
+FLUTTER_PLUGIN_EXPORT void audio_waveforms_plugin_register_with_registrar(FlPluginRegistrar* registrar);
+
+G_END_DECLS
+
+#endif  // FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_

--- a/macos/Classes/AudioWaveformsPlugin.swift
+++ b/macos/Classes/AudioWaveformsPlugin.swift
@@ -1,0 +1,14 @@
+import Cocoa
+import FlutterMacOS
+
+public class AudioWaveformsPlugin: NSObject, FlutterPlugin {
+  public static func register(with registrar: FlutterPluginRegistrar) {
+    let channel = FlutterMethodChannel(name: "simform_audio_waveforms_plugin/methods", binaryMessenger: registrar.messenger)
+    let instance = AudioWaveformsPlugin()
+    registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    result(FlutterError(code: "UNIMPLEMENTED", message: "AudioWaveforms desktop support is not yet implemented", details: call.method))
+  }
+}

--- a/macos/audio_waveforms.podspec
+++ b/macos/audio_waveforms.podspec
@@ -1,0 +1,15 @@
+Pod::Spec.new do |s|
+  s.name             = 'audio_waveforms'
+  s.version          = '0.0.1'
+  s.summary          = 'Desktop implementation stub.'
+  s.description      = 'Desktop implementation for audio_waveforms. Currently provides stub methods.'
+  s.homepage         = 'https://github.com/SimformSolutionsPvtLtd/audio_waveforms'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Simform' => 'info@simform.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'FlutterMacOS'
+  s.platform = :osx, '10.11'
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
+  s.swift_version = '5.0'
+end

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,4 +26,10 @@ flutter:
         pluginClass: AudioWaveformsPlugin
       ios:
         pluginClass: AudioWaveformsPlugin
+      macos:
+        pluginClass: AudioWaveformsPlugin
+      windows:
+        pluginClass: AudioWaveformsPlugin
+      linux:
+        pluginClass: AudioWaveformsPlugin
 

--- a/test/recorder_test.dart
+++ b/test/recorder_test.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audio_waveforms/audio_waveforms.dart';
+
+void main() {
+  test('RecorderController initializes', () {
+    final controller = RecorderController();
+    expect(controller.recorderState, RecorderState.stopped);
+  });
+}

--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.14)
+set(PROJECT_NAME "audio_waveforms")
+project(${PROJECT_NAME} LANGUAGES CXX)
+cmake_policy(VERSION 3.14...3.25)
+set(PLUGIN_NAME "audio_waveforms_plugin")
+list(APPEND PLUGIN_SOURCES
+  "audio_waveforms_plugin.cpp"
+  "audio_waveforms_plugin.h"
+)
+add_library(${PLUGIN_NAME} SHARED
+  "include/audio_waveforms/audio_waveforms_plugin_c_api.h"
+  "audio_waveforms_plugin_c_api.cpp"
+  ${PLUGIN_SOURCES}
+)
+apply_standard_settings(${PLUGIN_NAME})
+set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
+target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_include_directories(${PLUGIN_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
+target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+set(audio_waveforms_bundled_libraries
+  ""
+  PARENT_SCOPE
+)

--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -1,0 +1,37 @@
+#include "audio_waveforms_plugin.h"
+
+#include <flutter/plugin_registrar_windows.h>
+#include <flutter/method_channel.h>
+#include <flutter/standard_method_codec.h>
+
+#include <memory>
+
+namespace audio_waveforms {
+
+void AudioWaveformsPlugin::RegisterWithRegistrar(
+    flutter::PluginRegistrarWindows *registrar) {
+  auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
+      registrar->messenger(), "simform_audio_waveforms_plugin/methods",
+      &flutter::StandardMethodCodec::GetInstance());
+
+  auto plugin = std::make_unique<AudioWaveformsPlugin>();
+
+  channel->SetMethodCallHandler(
+      [plugin_pointer = plugin.get()](const auto &call, auto result) {
+        plugin_pointer->HandleMethodCall(call, std::move(result));
+      });
+
+  registrar->AddPlugin(std::move(plugin));
+}
+
+AudioWaveformsPlugin::AudioWaveformsPlugin() {}
+
+AudioWaveformsPlugin::~AudioWaveformsPlugin() {}
+
+void AudioWaveformsPlugin::HandleMethodCall(
+    const flutter::MethodCall<flutter::EncodableValue> &method_call,
+    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
+  result->Error("UNIMPLEMENTED", "AudioWaveforms desktop support is not yet implemented", method_call.method_name());
+}
+
+}  // namespace audio_waveforms

--- a/windows/audio_waveforms_plugin.h
+++ b/windows/audio_waveforms_plugin.h
@@ -1,0 +1,28 @@
+#ifndef FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_
+#define FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_
+
+#include <flutter/method_channel.h>
+#include <flutter/plugin_registrar_windows.h>
+
+#include <memory>
+
+namespace audio_waveforms {
+
+class AudioWaveformsPlugin : public flutter::Plugin {
+ public:
+  static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
+
+  AudioWaveformsPlugin();
+  virtual ~AudioWaveformsPlugin();
+
+  // Disallow copy and assign.
+  AudioWaveformsPlugin(const AudioWaveformsPlugin&) = delete;
+  AudioWaveformsPlugin& operator=(const AudioWaveformsPlugin&) = delete;
+
+  void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& call,
+                        std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+};
+
+}  // namespace audio_waveforms
+
+#endif  // FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_H_

--- a/windows/audio_waveforms_plugin_c_api.cpp
+++ b/windows/audio_waveforms_plugin_c_api.cpp
@@ -1,0 +1,10 @@
+#include "include/audio_waveforms/audio_waveforms_plugin_c_api.h"
+
+#include "audio_waveforms_plugin.h"
+
+void AudioWaveformsPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar) {
+  audio_waveforms::AudioWaveformsPlugin::RegisterWithRegistrar(
+      flutter::PluginRegistrarManager::GetInstance()
+          ->GetRegistrar<flutter::PluginRegistrarWindows>(registrar));
+}

--- a/windows/include/audio_waveforms/audio_waveforms_plugin_c_api.h
+++ b/windows/include/audio_waveforms/audio_waveforms_plugin_c_api.h
@@ -1,0 +1,23 @@
+#ifndef FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_C_API_H_
+#define FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_C_API_H_
+
+#include <flutter/plugin_registrar_windows.h>
+
+#ifdef AUDIO_WAVEFORMS_PLUGIN_IMPL
+#define AUDIO_WAVEFORMS_PLUGIN_EXPORT __declspec(dllexport)
+#else
+#define AUDIO_WAVEFORMS_PLUGIN_EXPORT __declspec(dllimport)
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+AUDIO_WAVEFORMS_PLUGIN_EXPORT void AudioWaveformsPluginCApiRegisterWithRegistrar(
+    FlutterDesktopPluginRegistrarRef registrar);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // FLUTTER_PLUGIN_AUDIO_WAVEFORMS_PLUGIN_C_API_H_


### PR DESCRIPTION
## Summary
- add stub plugin implementations for macOS, Windows and Linux
- document desktop setup requirements
- handle macOS platform checks in recorder controller and interface
- expose desktop stubs via pubspec
- add basic recorder controller unit test

## Testing
- `flutter test test/recorder_test.dart`

------
https://chatgpt.com/codex/tasks/task_e_686389375e948321ac0360bcde5e9834