### PR TITLE
Add desktop microphone permission handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **BREAKING:**
   - Remove duplicate parameters from RecorderController.
   - Add `RecorderSettings` model for all the recording settings.
+- Feature: Added microphone permission handling for macOS, Windows and Linux.
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -46,14 +46,26 @@ operating system.
 **macOS**
 
 - Add a microphone usage description to `macos/Runner/Info.plist`.
+  
+  ```xml
+  <key>NSMicrophoneUsageDescription</key>
+  <string>Need microphone access to record audio waveforms.</string>
+  ```
 
 **Windows**
 
 - Declare the `microphone` capability in the application manifest.
+  
+  ```xml
+  <Capabilities>
+      <DeviceCapability Name="microphone" />
+  </Capabilities>
+  ```
 
 **Linux**
 
-- Ensure PulseAudio (or another supported backend) is available.
+- Ensure PulseAudio (or another supported backend) is available. Linux does not
+  require special microphone permissions, but PulseAudio is needed for capture.
 
 </details>
 <details>

--- a/linux/audio_waveforms_plugin.cc
+++ b/linux/audio_waveforms_plugin.cc
@@ -2,6 +2,7 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+#include <unistd.h>
 
 struct _AudioWaveformsPlugin {
   GObject parent_instance;
@@ -14,10 +15,17 @@ static void audio_waveforms_plugin_handle_method_call(
     AudioWaveformsPlugin* self,
     FlMethodCall* method_call) {
   g_autoptr(FlMethodResponse) response = nullptr;
-  response = FL_METHOD_RESPONSE(fl_method_error_response_new(
-      "UNIMPLEMENTED",
-      "AudioWaveforms desktop support is not yet implemented",
-      fl_value_new_string(fl_method_call_get_name(method_call))));
+  const gchar* method = fl_method_call_get_name(method_call);
+
+  if (strcmp(method, "checkPermission") == 0) {
+    // Linux does not require microphone permission by default.
+    response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(true)));
+  } else {
+    response = FL_METHOD_RESPONSE(fl_method_error_response_new(
+        "UNIMPLEMENTED",
+        "AudioWaveforms desktop support is not yet implemented",
+        fl_value_new_string(method)));
+  }
   fl_method_call_respond(method_call, response, nullptr);
 }
 

--- a/macos/Classes/AudioWaveformsPlugin.swift
+++ b/macos/Classes/AudioWaveformsPlugin.swift
@@ -1,14 +1,35 @@
 import Cocoa
 import FlutterMacOS
+import AVFoundation
 
 public class AudioWaveformsPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
-    let channel = FlutterMethodChannel(name: "simform_audio_waveforms_plugin/methods", binaryMessenger: registrar.messenger)
+    let channel = FlutterMethodChannel(name: Constants.methodChannelName, binaryMessenger: registrar.messenger)
     let instance = AudioWaveformsPlugin()
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
-    result(FlutterError(code: "UNIMPLEMENTED", message: "AudioWaveforms desktop support is not yet implemented", details: call.method))
+    switch call.method {
+    case Constants.checkPermission:
+      checkPermission(result: result)
+    default:
+      result(FlutterError(code: Constants.audioWaveforms, message: "AudioWaveforms desktop support is not yet implemented", details: call.method))
+    }
+  }
+
+  private func checkPermission(result: @escaping FlutterResult) {
+    switch AVCaptureDevice.authorizationStatus(for: .audio) {
+    case .authorized:
+      result(true)
+    case .denied, .restricted:
+      result(false)
+    case .notDetermined:
+      AVCaptureDevice.requestAccess(for: .audio) { granted in
+        result(granted)
+      }
+    @unknown default:
+      result(false)
+    }
   }
 }

--- a/macos/Classes/Utils.swift
+++ b/macos/Classes/Utils.swift
@@ -1,0 +1,5 @@
+struct Constants {
+    static let methodChannelName = "simform_audio_waveforms_plugin/methods"
+    static let audioWaveforms = "AudioWaveforms"
+    static let checkPermission = "checkPermission"
+}

--- a/test/permission_test.dart
+++ b/test/permission_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:audio_waveforms/audio_waveforms.dart';
+import 'package:audio_waveforms/src/base/constants.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  const channel = MethodChannel(Constants.methodChannelName);
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+  });
+
+  test('checkPermission returns true from platform', () async {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      if (methodCall.method == Constants.checkPermission) {
+        return true;
+      }
+      return null;
+    });
+
+    final controller = RecorderController();
+    final hasPermission = await controller.checkPermission();
+    expect(hasPermission, isTrue);
+  });
+}

--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -5,13 +5,18 @@
 #include <flutter/standard_method_codec.h>
 
 #include <memory>
+#include <winrt/Windows.Devices.Enumeration.h>
 
 namespace audio_waveforms {
+using flutter::EncodableValue;
+using flutter::MethodCall;
+using flutter::MethodResult;
+using flutter::MethodChannel;
 
 void AudioWaveformsPlugin::RegisterWithRegistrar(
     flutter::PluginRegistrarWindows *registrar) {
-  auto channel = std::make_unique<flutter::MethodChannel<flutter::EncodableValue>>(
-      registrar->messenger(), "simform_audio_waveforms_plugin/methods",
+  auto channel = std::make_unique<MethodChannel<EncodableValue>>(registrar->messenger(),
+      "simform_audio_waveforms_plugin/methods",
       &flutter::StandardMethodCodec::GetInstance());
 
   auto plugin = std::make_unique<AudioWaveformsPlugin>();
@@ -29,9 +34,29 @@ AudioWaveformsPlugin::AudioWaveformsPlugin() {}
 AudioWaveformsPlugin::~AudioWaveformsPlugin() {}
 
 void AudioWaveformsPlugin::HandleMethodCall(
-    const flutter::MethodCall<flutter::EncodableValue> &method_call,
-    std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result) {
-  result->Error("UNIMPLEMENTED", "AudioWaveforms desktop support is not yet implemented", method_call.method_name());
+    const MethodCall<EncodableValue> &method_call,
+    std::unique_ptr<MethodResult<EncodableValue>> result) {
+  if (method_call.method_name() == "checkPermission") {
+    bool granted = false;
+    try {
+      using namespace winrt::Windows::Devices::Enumeration;
+      auto info = DeviceAccessInformation::CreateFromDeviceClass(DeviceClass::AudioCapture);
+      auto status = info.CurrentStatus();
+      if (status == DeviceAccessStatus::Allowed) {
+        granted = true;
+      } else if (status == DeviceAccessStatus::UserPromptRequired) {
+        status = info.RequestAccessAsync().get();
+        granted = status == DeviceAccessStatus::Allowed;
+      } else {
+        granted = false;
+      }
+    } catch (...) {
+      granted = false;
+    }
+    result->Success(EncodableValue(granted));
+  } else {
+    result->Error("UNIMPLEMENTED", "AudioWaveforms desktop support is not yet implemented", method_call.method_name());
+  }
 }
 
 }  // namespace audio_waveforms


### PR DESCRIPTION
## Summary
- add microphone permission check for macOS using `AVCaptureDevice`
- implement Windows permission check with `DeviceAccessInformation`
- return true for Linux since no extra permission is required
- document microphone permission snippets in README
- note new feature in changelog
- test permission via MethodChannel mocking

## Testing
- `flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68638ed233d48321928086956825a35b