### PR TITLE
Add player control unit tests

### DIFF
--- a/test/desktop_audio_handler_test.dart
+++ b/test/desktop_audio_handler_test.dart
@@ -27,4 +27,75 @@ void main() {
       path: anyNamed('path'),
     )).called(1);
   });
+
+  group('player controls', () {
+    const testKey = 'key';
+    const testPath = '/tmp/test.m4a';
+
+    late MockAudioPlayer mockPlayer;
+    late DesktopAudioHandler handler;
+
+    setUp(() {
+      mockPlayer = MockAudioPlayer();
+      handler = DesktopAudioHandler(
+        recorder: MockAudioRecorder(),
+        playerFactory: () => mockPlayer,
+      );
+      when(mockPlayer.setFilePath(any)).thenAnswer((_) async => null);
+      when(mockPlayer.setVolume(any)).thenAnswer((_) async => null);
+      when(mockPlayer.play()).thenAnswer((_) async {});
+      when(mockPlayer.pause()).thenAnswer((_) async {});
+      when(mockPlayer.stop()).thenAnswer((_) async {});
+      when(mockPlayer.seek(any)).thenAnswer((_) async {});
+    });
+
+    test('startPlayer calls play on AudioPlayer', () async {
+      await handler.preparePlayer(
+        path: testPath,
+        key: testKey,
+        frequency: 1,
+      );
+
+      final started = await handler.startPlayer(testKey);
+
+      expect(started, isTrue);
+      verify(mockPlayer.play()).called(1);
+    });
+
+    test('pausePlayer calls pause on AudioPlayer', () async {
+      await handler.preparePlayer(path: testPath, key: testKey, frequency: 1);
+
+      final paused = await handler.pausePlayer(testKey);
+
+      expect(paused, isTrue);
+      verify(mockPlayer.pause()).called(1);
+    });
+
+    test('stopPlayer calls stop on AudioPlayer', () async {
+      await handler.preparePlayer(path: testPath, key: testKey, frequency: 1);
+
+      final stopped = await handler.stopPlayer(testKey);
+
+      expect(stopped, isTrue);
+      verify(mockPlayer.stop()).called(1);
+    });
+
+    test('setVolume clamps value and calls setVolume on AudioPlayer', () async {
+      await handler.preparePlayer(path: testPath, key: testKey, frequency: 1);
+
+      final success = await handler.setVolume(2.0, testKey);
+
+      expect(success, isTrue);
+      verify(mockPlayer.setVolume(1.0)).called(1);
+    });
+
+    test('seekTo calls seek with given progress', () async {
+      await handler.preparePlayer(path: testPath, key: testKey, frequency: 1);
+
+      final success = await handler.seekTo(testKey, 500);
+
+      expect(success, isTrue);
+      verify(mockPlayer.seek(const Duration(milliseconds: 500))).called(1);
+    });
+  });
 }

--- a/test/permission_test.dart
+++ b/test/permission_test.dart
@@ -6,14 +6,29 @@ import 'package:audio_waveforms/src/base/constants.dart';
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
   const channel = MethodChannel(Constants.methodChannelName);
+  const recordChannel = MethodChannel('com.llfbandit.record/messages');
 
   tearDown(() {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    final messenger = TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, null);
+    messenger.setMockMethodCallHandler(recordChannel, null);
   });
 
   test('checkPermission returns true from platform', () async {
-    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+    final messenger = TestDefaultBinaryMessengerBinding
+        .instance.defaultBinaryMessenger;
+    messenger.setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       if (methodCall.method == Constants.checkPermission) {
+        return true;
+      }
+      return null;
+    });
+    messenger.setMockMethodCallHandler(recordChannel, (MethodCall methodCall) async {
+      if (methodCall.method == 'create') {
+        return null;
+      }
+      if (methodCall.method == 'hasPermission') {
         return true;
       }
       return null;


### PR DESCRIPTION
## Summary
- expand `desktop_audio_handler_test.dart` with tests for the player API
- mock the record plugin in `permission_test.dart` so tests run on desktop

## Testing
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686396ac1e2c8321852d38d29f06b4e9