### PR TITLE
Implement desktop method channel delegation

### DIFF
--- a/lib/src/base/constants.dart
+++ b/lib/src/base/constants.dart
@@ -3,6 +3,8 @@ class Constants {
 
   static const String methodChannelName =
       'simform_audio_waveforms_plugin/methods';
+  static const String desktopChannelName =
+      'simform_audio_waveforms_plugin/desktop';
   static const String initRecorder = 'initRecorder';
   static const String startRecording = 'startRecording';
   static const String stopRecording = 'stopRecording';

--- a/lib/src/base/desktop_audio_handler.dart
+++ b/lib/src/base/desktop_audio_handler.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 
 import 'package:just_audio/just_audio.dart';
 import 'package:record/record.dart' show AudioRecorder, RecordConfig, AudioEncoder;
+import 'package:flutter/services.dart';
 import 'package:just_waveform/just_waveform.dart';
 
 import '../models/recorder_settings.dart';
@@ -12,7 +13,25 @@ import 'utils.dart';
 class DesktopAudioHandler {
   DesktopAudioHandler({AudioRecorder? recorder, AudioPlayer Function()? playerFactory})
       : _recorder = recorder ?? AudioRecorder(),
-        _playerFactory = playerFactory ?? (() => AudioPlayer());
+        _playerFactory = playerFactory ?? (() => AudioPlayer()) {
+    _desktopChannel.setMethodCallHandler(_handleMethodCall);
+  }
+
+  static const MethodChannel _desktopChannel =
+      MethodChannel(Constants.desktopChannelName);
+
+  Future<dynamic> _handleMethodCall(MethodCall call) async {
+    switch (call.method) {
+      case Constants.checkPermission:
+        return checkPermission();
+      default:
+        throw PlatformException(
+          code: 'AudioWaveforms',
+          message: 'Method not implemented',
+          details: call.method,
+        );
+    }
+  }
 
   final AudioRecorder _recorder;
   final AudioPlayer Function() _playerFactory;

--- a/macos/Classes/AudioWaveformsPlugin.swift
+++ b/macos/Classes/AudioWaveformsPlugin.swift
@@ -5,14 +5,22 @@ import AVFoundation
 public class AudioWaveformsPlugin: NSObject, FlutterPlugin {
   public static func register(with registrar: FlutterPluginRegistrar) {
     let channel = FlutterMethodChannel(name: Constants.methodChannelName, binaryMessenger: registrar.messenger)
-    let instance = AudioWaveformsPlugin()
+    let desktop = FlutterMethodChannel(name: Constants.desktopChannelName, binaryMessenger: registrar.messenger)
+    let instance = AudioWaveformsPlugin(desktopChannel: desktop)
     registrar.addMethodCallDelegate(instance, channel: channel)
+  }
+
+  private let desktopChannel: FlutterMethodChannel
+
+  init(desktopChannel: FlutterMethodChannel) {
+    self.desktopChannel = desktopChannel
+    super.init()
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
     switch call.method {
     case Constants.checkPermission:
-      checkPermission(result: result)
+      desktopChannel.invokeMethod(call.method, arguments: nil, result: result)
     default:
       result(FlutterError(code: Constants.audioWaveforms, message: "AudioWaveforms desktop support is not yet implemented", details: call.method))
     }

--- a/macos/Classes/Utils.swift
+++ b/macos/Classes/Utils.swift
@@ -1,5 +1,6 @@
 struct Constants {
     static let methodChannelName = "simform_audio_waveforms_plugin/methods"
+    static let desktopChannelName = "simform_audio_waveforms_plugin/desktop"
     static let audioWaveforms = "AudioWaveforms"
     static let checkPermission = "checkPermission"
 }

--- a/test/desktop_audio_handler_test.dart
+++ b/test/desktop_audio_handler_test.dart
@@ -1,18 +1,23 @@
 import 'package:audio_waveforms/src/base/desktop_audio_handler.dart';
 import 'package:audio_waveforms/src/models/recorder_settings.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/services.dart';
+import 'dart:async';
 import 'package:mockito/mockito.dart';
 import 'package:mockito/annotations.dart';
 import 'package:record/record.dart' show AudioRecorder, RecordConfig, AudioEncoder;
 import 'package:just_audio/just_audio.dart';
+import 'package:audio_waveforms/src/base/constants.dart';
 import 'desktop_audio_handler_test.mocks.dart';
 
 @GenerateMocks([AudioRecorder, AudioPlayer])
 void main() {
   test('record starts recording when permission granted', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
     final mockRecorder = MockAudioRecorder();
     when(mockRecorder.hasPermission()).thenAnswer((_) async => true);
-    when(mockRecorder.start(any, path: anyNamed('path'))).thenAnswer((_) async {});
+    when(mockRecorder.start(any, path: anyNamed('path')))
+        .thenAnswer((_) async => null);
 
     final handler = DesktopAudioHandler(
       recorder: mockRecorder,
@@ -26,5 +31,33 @@ void main() {
       any,
       path: anyNamed('path'),
     )).called(1);
+  });
+
+  test('checkPermission via method channel delegates to handler', () async {
+    TestWidgetsFlutterBinding.ensureInitialized();
+    final mockRecorder = MockAudioRecorder();
+    when(mockRecorder.hasPermission()).thenAnswer((_) async => true);
+
+    final handler = DesktopAudioHandler(
+      recorder: mockRecorder,
+      playerFactory: () => MockAudioPlayer(),
+    );
+
+    const codec = StandardMethodCodec();
+    final messenger =
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger;
+    final completer = Completer<ByteData?>();
+    messenger.handlePlatformMessage(
+      Constants.desktopChannelName,
+      codec.encodeMethodCall(
+        const MethodCall(Constants.checkPermission),
+      ),
+      (data) => completer.complete(data),
+    );
+    final reply = await completer.future ?? ByteData(0);
+    final result = codec.decodeEnvelope(reply) as bool;
+
+    expect(result, isTrue);
+    verify(mockRecorder.hasPermission()).called(1);
   });
 }

--- a/test/permission_test.dart
+++ b/test/permission_test.dart
@@ -1,20 +1,34 @@
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/foundation.dart';
 import 'package:audio_waveforms/audio_waveforms.dart';
 import 'package:audio_waveforms/src/base/constants.dart';
 
 void main() {
+  debugDefaultTargetPlatformOverride = TargetPlatform.android;
   TestWidgetsFlutterBinding.ensureInitialized();
   const channel = MethodChannel(Constants.methodChannelName);
+  const recordChannel = MethodChannel('com.llfbandit.record/messages');
 
   tearDown(() {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, null);
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(recordChannel, null);
+    debugDefaultTargetPlatformOverride = null;
   });
 
   test('checkPermission returns true from platform', () async {
     TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(channel, (MethodCall methodCall) async {
       if (methodCall.method == Constants.checkPermission) {
         return true;
+      }
+      return null;
+    });
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(recordChannel, (MethodCall methodCall) async {
+      if (methodCall.method == 'hasPermission') {
+        return true;
+      }
+      if (methodCall.method == 'create') {
+        return null;
       }
       return null;
     });

--- a/windows/audio_waveforms_plugin.h
+++ b/windows/audio_waveforms_plugin.h
@@ -12,7 +12,7 @@ class AudioWaveformsPlugin : public flutter::Plugin {
  public:
   static void RegisterWithRegistrar(flutter::PluginRegistrarWindows *registrar);
 
-  AudioWaveformsPlugin();
+  AudioWaveformsPlugin(std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> desktop);
   virtual ~AudioWaveformsPlugin();
 
   // Disallow copy and assign.
@@ -21,6 +21,9 @@ class AudioWaveformsPlugin : public flutter::Plugin {
 
   void HandleMethodCall(const flutter::MethodCall<flutter::EncodableValue>& call,
                         std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
+
+ private:
+  std::unique_ptr<flutter::MethodChannel<flutter::EncodableValue>> desktop_channel_;
 };
 
 }  // namespace audio_waveforms


### PR DESCRIPTION
## Summary
- route desktop plugins to new `desktop` method channel
- expose a desktop handler method channel in Dart
- test channel delegation
- update permission test configuration

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686398ffb2508321ae20b3de41c31e5e