### PR TITLE
Update plugin Java 21 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 - **BREAKING:**
   - Remove duplicate parameters from RecorderController.
   - Add `RecorderSettings` model for all the recording settings.
+- **BREAKING:** Require Java 21 and Kotlin 2.x for the Android build.
 
 ## 1.3.0
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ any position while playing audio and style waveforms.
         audio_waveforms: <latest-version>
     ```
 2. Make sure delete the app from your device and perform `flutter clean` and then `flutter pub get`
+3. Ensure your Android build is configured for Java 21 and Kotlin 2.x.
 
 # Usage
 ## Recorder

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,7 +2,7 @@ group 'com.simform.audio_waveforms'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()
@@ -32,12 +32,12 @@ android {
     compileSdk 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
 
     sourceSets {

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -32,12 +32,12 @@ android {
     compileSdk 34
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_21
+        targetCompatibility JavaVersion.VERSION_21
     }
 
     kotlinOptions {
-        jvmTarget = '1.8'
+        jvmTarget = '21'
     }
 
     sourceSets {

--- a/example/android/build.gradle
+++ b/example/android/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.8.20'
+    ext.kotlin_version = '2.0.0'
     repositories {
         google()
         mavenCentral()

--- a/test/build_gradle_config_test.dart
+++ b/test/build_gradle_config_test.dart
@@ -1,0 +1,11 @@
+import 'dart:io';
+import 'package:test/test.dart';
+
+void main() {
+  test('android build.gradle uses Java 21 and Kotlin 2', () {
+    final gradleFile = File('android/build.gradle').readAsStringSync();
+    expect(gradleFile.contains("jvmTarget = '21'"), isTrue);
+    expect(gradleFile.contains('VERSION_21'), isTrue);
+    expect(gradleFile.contains("ext.kotlin_version = '2"), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add failing test for bytecode target
- bump Kotlin plugin to 2.0 and compile to Java 21
- update example build files to Java 21
- document new Java requirement

## Testing
- `dart test` *(fails: dart: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863869a4cf08321b3d1c69798c1d6de