### PR TITLE
Implement desktop recorder controls

### DIFF
--- a/lib/src/base/desktop_audio_handler.dart
+++ b/lib/src/base/desktop_audio_handler.dart
@@ -48,11 +48,16 @@ class DesktopAudioHandler {
   Future<Map<String, dynamic>> stop() async {
     final filePath = await _recorder.stop();
     if (filePath == null) return {};
-    final player = AudioPlayer();
+
+    final player = _playerFactory();
     await player.setFilePath(filePath);
     final duration = player.duration?.inMilliseconds ?? 0;
     await player.dispose();
-    return {Constants.resultFilePath: filePath, Constants.resultDuration: duration};
+
+    return {
+      Constants.resultFilePath: filePath,
+      Constants.resultDuration: duration,
+    };
   }
 
   Future<bool> resume() async {


### PR DESCRIPTION
## Summary
- refactor DesktopAudioHandler.stop to use provided playerFactory
- add tests for desktop recorder pause, resume, and stop

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6863ace7385c8321b75e666a18a9a4ac