### PR TITLE
Fix Windows plugin build

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -14,7 +14,11 @@ add_library(${PLUGIN_NAME} SHARED
 )
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES CXX_VISIBILITY_PRESET hidden)
-target_compile_definitions(${PLUGIN_NAME} PRIVATE FLUTTER_PLUGIN_IMPL)
+target_compile_definitions(
+  ${PLUGIN_NAME}
+  PRIVATE
+  FLUTTER_PLUGIN_IMPL
+  AUDIO_WAVEFORMS_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
 set(audio_waveforms_bundled_libraries

--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -40,16 +40,10 @@ void AudioWaveformsPlugin::HandleMethodCall(
     bool granted = false;
     try {
       using namespace winrt::Windows::Devices::Enumeration;
-      auto info = DeviceAccessInformation::CreateFromDeviceClass(DeviceClass::AudioCapture);
-      auto status = info.CurrentStatus();
-      if (status == DeviceAccessStatus::Allowed) {
-        granted = true;
-      } else if (status == DeviceAccessStatus::UserPromptRequired) {
-        status = info.RequestAccessAsync().get();
-        granted = status == DeviceAccessStatus::Allowed;
-      } else {
-        granted = false;
-      }
+      auto info =
+          DeviceAccessInformation::CreateFromDeviceClass(DeviceClass::AudioCapture);
+      auto status = info.RequestAccessAsync().get();
+      granted = status == DeviceAccessStatus::Allowed;
     } catch (...) {
       granted = false;
     }


### PR DESCRIPTION
## Summary
- export plugin symbols correctly on Windows
- request microphone access without using Windows version-specific constants

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6866191c25c88321b05baa7b7497fe78