### PR TITLE
Fix windows microphone permission fallback

### DIFF
--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -28,7 +28,11 @@ bool RequestMicrophonePermission() {
       using namespace winrt::Windows::Devices::Enumeration;
       const auto info =
           DeviceAccessInformation::CreateFromDeviceClass(DeviceClass::AudioCapture);
+#if WINVER >= 0x0A00
       const auto status = info.RequestAccessAsync().get();
+#else
+      const auto status = info.RequestAccess();
+#endif
       return status == DeviceAccessStatus::Allowed;
     } catch (const winrt::hresult_error& e) {
       std::cerr << "Microphone permission request failed: "


### PR DESCRIPTION
## Summary
- fallback to RequestAccess when older Windows SDK lacks RequestAccessAsync

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6866e1f21afc8321b5f8033991045113