### PR TITLE
Fix linking of Windows plugin

### DIFF
--- a/windows/CMakeLists.txt
+++ b/windows/CMakeLists.txt
@@ -21,6 +21,7 @@ target_compile_definitions(
   AUDIO_WAVEFORMS_PLUGIN_IMPL)
 target_include_directories(${PLUGIN_NAME} INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_link_libraries(${PLUGIN_NAME} PRIVATE flutter flutter_wrapper_plugin)
+target_link_libraries(audio_waveforms_plugin PRIVATE windowsapp)
 set(audio_waveforms_bundled_libraries
   ""
   PARENT_SCOPE


### PR DESCRIPTION
## Summary
- link audio_waveforms_plugin with `windowsapp` to access async WinRT APIs

## Testing
- `flutter test --machine`

------
https://chatgpt.com/codex/tasks/task_e_68681848bc9c832191e591511b2c2fad