### PR TITLE
Declare desktop platform support

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,3 +38,10 @@ flutter:
       linux:
         pluginClass: AudioWaveformsPlugin
 
+platforms:
+  android:
+  ios:
+  macos:
+  windows:
+  linux:
+


### PR DESCRIPTION
## Summary
- declare Windows, macOS and Linux platforms in `pubspec.yaml`

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_68681806e30c832180aa7ca7140d5956