### PR TITLE
Improve desktop plugin error messages

### DIFF
--- a/linux/audio_waveforms_plugin.cc
+++ b/linux/audio_waveforms_plugin.cc
@@ -21,10 +21,14 @@ static void audio_waveforms_plugin_handle_method_call(
     // Linux does not require microphone permission by default.
     response = FL_METHOD_RESPONSE(fl_method_success_response_new(fl_value_new_bool(true)));
   } else {
+    gchar* details = g_strdup_printf(
+        "Method '%s' is not implemented for desktop. Try using RecorderController or PlayerController from the audio_waveforms package instead.",
+        method);
     response = FL_METHOD_RESPONSE(fl_method_error_response_new(
         "UNIMPLEMENTED",
-        "AudioWaveforms desktop support is not yet implemented",
+        details,
         fl_value_new_string(method)));
+    g_free(details);
   }
   fl_method_call_respond(method_call, response, nullptr);
 }

--- a/macos/Classes/AudioWaveformsPlugin.swift
+++ b/macos/Classes/AudioWaveformsPlugin.swift
@@ -14,7 +14,8 @@ public class AudioWaveformsPlugin: NSObject, FlutterPlugin {
     case Constants.checkPermission:
       checkPermission(result: result)
     default:
-      result(FlutterError(code: Constants.audioWaveforms, message: "AudioWaveforms desktop support is not yet implemented", details: call.method))
+      let details = "Method \(call.method) is not implemented for desktop. Try using RecorderController or PlayerController from the audio_waveforms package instead."
+      result(FlutterError(code: Constants.audioWaveforms, message: details, details: call.method))
     }
   }
 

--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -66,7 +66,12 @@ void AudioWaveformsPlugin::HandleMethodCall(
     const bool granted = RequestMicrophonePermission();
     result->Success(EncodableValue(granted));
   } else {
-    result->Error("UNIMPLEMENTED", "AudioWaveforms desktop support is not yet implemented", method_call.method_name());
+    std::string message =
+        "Method '" + std::string(method_call.method_name()) +
+        "' is not implemented for desktop. "
+        "Try using RecorderController or PlayerController from the "
+        "audio_waveforms package instead.";
+    result->Error("UNIMPLEMENTED", message, method_call.method_name());
   }
 }
 


### PR DESCRIPTION
## Summary
- clarify unsupported method errors on desktop

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6868186ddb44832199fad9e43f914a95