### PR TITLE
Improve Windows microphone permission logic

### DIFF
--- a/windows/audio_waveforms_plugin.cpp
+++ b/windows/audio_waveforms_plugin.cpp
@@ -18,12 +18,13 @@ namespace {
 bool RequestMicrophonePermission() {
   using namespace winrt::Windows::Devices::Enumeration;
   try {
-    const auto info =
+    // Is any Audio-Capture device currently allowed?
+    auto info =
         DeviceAccessInformation::CreateFromDeviceClass(DeviceClass::AudioCapture);
-    const auto status = info.RequestAccessAsync().get();
+    auto status = info.CurrentStatus();  // <- synchronous property
     return status == DeviceAccessStatus::Allowed;
   } catch (const winrt::hresult_error& e) {
-    std::cerr << "Microphone permission request failed: "
+    std::cerr << "Microphone permission check failed: "
               << winrt::to_string(e.message()) << std::endl;
     return false;
   }


### PR DESCRIPTION
## Summary
- check microphone permission synchronously on Windows

## Testing
- `./flutter-sdk/bin/flutter test`

------
https://chatgpt.com/codex/tasks/task_e_686af1884ad883219b52b0ece3c5b2e5